### PR TITLE
Upgrading according to latest three.js version

### DIFF
--- a/build/webaudiox.js
+++ b/build/webaudiox.js
@@ -404,7 +404,7 @@ WebAudiox.ListenerSetObject3D	= function(context, object3d){
 	var matrixWorld	= object3d.matrixWorld
 	////////////////////////////////////////////////////////////////////////
 	// set position
-	var position	= new THREE.Vector3().getPositionFromMatrix(matrixWorld)
+	var position	= new THREE.Vector3().setFromMatrixPosition(matrixWorld)
 	context.listener.setPosition(position.x, position.y, position.z)
 
 	////////////////////////////////////////////////////////////////////////
@@ -441,9 +441,9 @@ WebAudiox.ListenerObject3DUpdater	= function(context, object3d){
 		// set velocity
 		var matrixWorld	= object3d.matrixWorld
 		if( prevPosition === null ){
-			prevPosition	= new THREE.Vector3().getPositionFromMatrix(matrixWorld);
+			prevPosition	= new THREE.Vector3().setFromMatrixPosition(matrixWorld);
 		}else{
-			var position	= new THREE.Vector3().getPositionFromMatrix(matrixWorld);
+			var position	= new THREE.Vector3().setFromMatrixPosition(matrixWorld);
 			var velocity	= position.clone().sub(prevPosition).divideScalar(delta);
 			prevPosition.copy(position)
 			context.listener.setVelocity(velocity.x, velocity.y, velocity.z);
@@ -481,7 +481,7 @@ WebAudiox.PannerSetObject3D	= function(panner, object3d){
 	
 	////////////////////////////////////////////////////////////////////////
 	// set position
-	var position	= new THREE.Vector3().getPositionFromMatrix(matrixWorld)
+	var position	= new THREE.Vector3().setFromMatrixPosition(matrixWorld)
 	panner.setPosition(position.x, position.y, position.z)
 
 	////////////////////////////////////////////////////////////////////////
@@ -517,9 +517,9 @@ WebAudiox.PannerObject3DUpdater	= function(panner, object3d){
 		// set velocity
 		var matrixWorld	= object3d.matrixWorld
 		if( prevPosition === null ){
-			prevPosition	= new THREE.Vector3().getPositionFromMatrix(matrixWorld);
+			prevPosition	= new THREE.Vector3().setFromMatrixPosition(matrixWorld);
 		}else{
-			var position	= new THREE.Vector3().getPositionFromMatrix(matrixWorld);
+			var position	= new THREE.Vector3().setFromMatrixPosition(matrixWorld);
 			var velocity	= position.clone().sub(prevPosition).divideScalar(delta);
 			prevPosition.copy( position )
 			panner.setVelocity(velocity.x, velocity.y, velocity.z);


### PR DESCRIPTION
Hello!

First of all, let me say many many thanks for your effort to develop this, to my taste, nifty piece of code for using webaudio together with three.js! It makes it much easier for me to start with audio in 3D during my own efforts in three.js construction works.

What I in this little fork just did is; Replaced every appearance of the method name .getPositionFromMatrix() with .setFromMatrixPosition().

Actually, I am not sure, if you already before may have considered upgrading the otherwise deprecated method name to the new one? It only creates a warning message, and sure enough, remaining with the old method name users of the script, who stick to the older three.js versions can keep using it. I am still new to the question of maintaining scripts, therefore only in case you did not notice the deprecation issue, and not having gauged the benefits and the drawbacks yourself, yet, I consider it may be of relevance. The more so, I feel encouraged to propose this to you, as I could see that the according method has been renamed in case of your other scripts  threex.transparency.js and threex.objcoord.js as well.

And as I like to keep in mind always Winnie the Pooh while continuing some construction work with the coding ... http://orig01.deviantart.net/8db6/f/2011/049/8/5/winnie_the_pooh_by_jo_from_kokomo-d39toyl.jpg

Regards
Robert
