### PR TITLE
Fix/loadbuffer status error and progress count

### DIFF
--- a/build/webaudiox.js
+++ b/build/webaudiox.js
@@ -317,7 +317,7 @@ var WebAudiox	= WebAudiox	|| {}
 
 /**
  * Helper to load a buffer
- * 
+ *
  * @param  {AudioContext} context the WebAudio API context
  * @param  {String} url     the url of the sound to load
  * @param  {Function} onLoad  callback to notify when the buffer is loaded and decoded
@@ -336,19 +336,27 @@ WebAudiox.loadBuffer	= function(context, url, onLoad, onError){
 	// counter inProgress request
 	WebAudiox.loadBuffer.inProgressCount++
 	request.onload	= function(){
-		context.decodeAudioData(request.response, function(buffer){
+		// Check XMLHttpRequest.status or FileReader.error parameter
+		if( request.status < 400 || (!request.status && !request.error) ){
+			context.decodeAudioData(request.response, function(buffer){
+				// counter inProgress request
+				WebAudiox.loadBuffer.inProgressCount--
+				// notify the callback
+				onLoad(buffer)
+				// notify
+				WebAudiox.loadBuffer.onLoad(context, url, buffer)
+			}, function(){
+				// counter inProgress request
+				WebAudiox.loadBuffer.inProgressCount--
+				// notify the callback
+				onError()
+			})
+		} else {
 			// counter inProgress request
 			WebAudiox.loadBuffer.inProgressCount--
-			// notify the callback
-			onLoad(buffer)			
-			// notify
-			WebAudiox.loadBuffer.onLoad(context, url, buffer)
-		}, function(){
 			// notify the callback
 			onError()
-			// counter inProgress request
-			WebAudiox.loadBuffer.inProgressCount--
-		})
+		}
 	}
 	request.send()
 }

--- a/lib/webaudiox.loadbuffer.js
+++ b/lib/webaudiox.loadbuffer.js
@@ -22,7 +22,7 @@ WebAudiox.loadBuffer	= function(context, url, onLoad, onError){
 	WebAudiox.loadBuffer.inProgressCount++
 	request.onload	= function(){
 		// Check XMLHttpRequest.status or FileReader.error parameter
-		if( (request.status && request.status < 400) || (!request.status && !request.error) ){
+		if( request.status < 400 || (!request.status && !request.error) ){
 			context.decodeAudioData(request.response, function(buffer){
 				// counter inProgress request
 				WebAudiox.loadBuffer.inProgressCount--

--- a/lib/webaudiox.loadbuffer.js
+++ b/lib/webaudiox.loadbuffer.js
@@ -2,7 +2,7 @@ var WebAudiox	= WebAudiox	|| {}
 
 /**
  * Helper to load a buffer
- * 
+ *
  * @param  {AudioContext} context the WebAudio API context
  * @param  {String} url     the url of the sound to load
  * @param  {Function} onLoad  callback to notify when the buffer is loaded and decoded
@@ -25,14 +25,14 @@ WebAudiox.loadBuffer	= function(context, url, onLoad, onError){
 			// counter inProgress request
 			WebAudiox.loadBuffer.inProgressCount--
 			// notify the callback
-			onLoad(buffer)			
+			onLoad(buffer)
 			// notify
 			WebAudiox.loadBuffer.onLoad(context, url, buffer)
 		}, function(){
-			// notify the callback
-			onError()
 			// counter inProgress request
 			WebAudiox.loadBuffer.inProgressCount--
+			// notify the callback
+			onError()
 		})
 	}
 	request.send()

--- a/lib/webaudiox.loadbuffer.js
+++ b/lib/webaudiox.loadbuffer.js
@@ -21,19 +21,27 @@ WebAudiox.loadBuffer	= function(context, url, onLoad, onError){
 	// counter inProgress request
 	WebAudiox.loadBuffer.inProgressCount++
 	request.onload	= function(){
-		context.decodeAudioData(request.response, function(buffer){
-			// counter inProgress request
-			WebAudiox.loadBuffer.inProgressCount--
-			// notify the callback
-			onLoad(buffer)
-			// notify
-			WebAudiox.loadBuffer.onLoad(context, url, buffer)
-		}, function(){
+		// Check XMLHttpRequest.status or FileReader.error parameter
+		if( (request.status && request.status < 400) || (!request.status && !request.error) ){
+			context.decodeAudioData(request.response, function(buffer){
+				// counter inProgress request
+				WebAudiox.loadBuffer.inProgressCount--
+				// notify the callback
+				onLoad(buffer)
+				// notify
+				WebAudiox.loadBuffer.onLoad(context, url, buffer)
+			}, function(){
+				// counter inProgress request
+				WebAudiox.loadBuffer.inProgressCount--
+				// notify the callback
+				onError()
+			})
+		} else {
 			// counter inProgress request
 			WebAudiox.loadBuffer.inProgressCount--
 			// notify the callback
 			onError()
-		})
+		}
 	}
 	request.send()
 }


### PR DESCRIPTION
Addresses two issues found using loadBuffer
1. When the audio data request failed, HTTP status errors were ignored and decodeAudioData was invoked with invalid data resulting
2. On errors the inProgressCount parameter was updated after the call to the client's onError method making it more difficult for the client to determine whether all pending files had been loaded.
